### PR TITLE
Relax time dependency

### DIFF
--- a/rrule.cabal
+++ b/rrule.cabal
@@ -35,7 +35,7 @@ library
     , megaparsec         >= 8.0.0 && < 8.1
     , text               >= 1.2.3 && < 1.3
     , parser-combinators >= 1.2.1 && < 1.3
-    , time               >= 1.8.0 && < 1.9
+    , time               >= 1.8.0 && < 1.12
   default-extensions:
       OverloadedStrings
     , LambdaCase


### PR DESCRIPTION
The time dependency can be relaxed to include the newest version of time. This pull request relaxes the dependency.