### PR TITLE
Allow UNTIL with plain dates

### DIFF
--- a/src/Data/Time/RRule.hs
+++ b/src/Data/Time/RRule.hs
@@ -19,6 +19,7 @@ import Data.Time.RRule.Types as Ty
   , RRule(..)
   , Day(..)
   , Frequency(..)
+  , TimeOrDate(..)
   , ToRRule(toRRule)
   )
 import Text.Megaparsec (parseMaybe)
@@ -146,8 +147,9 @@ frequencyDescription freq = case freq of
 countDescription :: Int -> Text
 countDescription n = "for " <> showText n <> " occurrences"
 
-untilDescription :: UTCTime -> Text
-untilDescription t = "until " <> (pack $ formatTime defaultTimeLocale "%B %d, %Y at %H:%M:%S" t)
+untilDescription :: Ty.TimeOrDate -> Text
+untilDescription (Ty.Time t) = "until " <> (pack $ formatTime defaultTimeLocale "%B %d, %Y at %H:%M:%S" t)
+untilDescription (Ty.Date d) = "until " <> (pack $ formatTime defaultTimeLocale "%B %d, %Y" d)
 
 weekStartDescription :: Day -> Text
 weekStartDescription d = "with weeks starting on " <> showText d

--- a/src/Data/Time/RRule/Parse.hs
+++ b/src/Data/Time/RRule/Parse.hs
@@ -2,7 +2,6 @@ module Data.Time.RRule.Parse
   ( parseRRule
   )
 where
-import Debug.Trace (traceShow)
 import Prelude hiding (until)
 import Control.Monad (msum)
 import qualified Control.Monad.Combinators.NonEmpty as NE

--- a/src/Data/Time/RRule/Parse.hs
+++ b/src/Data/Time/RRule/Parse.hs
@@ -2,7 +2,7 @@ module Data.Time.RRule.Parse
   ( parseRRule
   )
 where
-
+import Debug.Trace (traceShow)
 import Prelude hiding (until)
 import Control.Monad (msum)
 import qualified Control.Monad.Combinators.NonEmpty as NE
@@ -11,9 +11,10 @@ import Data.Maybe (fromMaybe, catMaybes, isJust)
 import Data.Text (Text, intercalate, pack, unpack)
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (parseTimeM, defaultTimeLocale)
-import Data.Time.RRule.Types (defaultRRule, RRule(..), Day(..), Frequency(..), ToRRule)
+import Data.Time.RRule.Types (defaultRRule, RRule(..), Day(..), Frequency(..), ToRRule, TimeOrDate(..))
 import Text.Megaparsec hiding (count)
 import Text.Megaparsec.Char.Lexer
+import qualified Data.Time.Calendar as Cal (Day, toGregorian)
 
 type Parser = Parsec () Text
 
@@ -50,7 +51,7 @@ parseVariable = do
   weekStart  <- parseVar "WKST"       parseDay
   frequency  <- parseVar "FREQ"       parseFrequency
   count      <- parseVar "COUNT"      decimal
-  until      <- parseVar "UNTIL"      parseUtcTime
+  until      <- parseVar "UNTIL"      parseTimeOrDate
   interval   <- parseVar "INTERVAL"   decimal
   bySecond   <- parseVar "BYSECOND"   parseSomeInt
   byMinute   <- parseVar "BYMINUTE"   parseSomeInt
@@ -83,6 +84,14 @@ parseIntDay = do
   n <- try . optional $ parseInt
   d <- parseDay
   return (fromMaybe 0 n, d)
+
+parseTimeOrDate :: Parser TimeOrDate
+parseTimeOrDate = fmap Time (try parseUtcTime) <|> fmap Date parseDate
+
+parseDate :: Parser Cal.Day
+parseDate = do
+  d <- takeP Nothing 8
+  parseTimeM False defaultTimeLocale "%Y%m%d" (unpack d)
 
 parseUtcTime :: Parser UTCTime
 parseUtcTime = do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -96,6 +96,12 @@ main = hspec $ do
     it "yearly in June and July for 10 occurrences" $ do
       roundTrip "FREQ=YEARLY;COUNT=10;BYMONTH=6,7"
 
+    it "every month on Tuesday until November 30, 2021" $ do
+      roundTrip "RRULE:BYDAY=TU;INTERVAL=1;FREQ=MONTHLY;UNTIL=20211130"
+
+    it "every other week on Friday until November 19, 1997" $ do
+      roundTrip "RRULE:BYDAY=FR;INTERVAL=2;FREQ=WEEKLY;UNTIL=19971119"
+
     it "every other year on January, February, and March for 10 occurrences" $ do
       roundTrip  "FREQ=YEARLY;INTERVAL=2;COUNT=10;BYMONTH=1,2,3"
 
@@ -310,6 +316,14 @@ main = hspec $ do
     it "every 3 hours until 5:00 PM on a specific day" $ do
       description <$> fromText "FREQ=HOURLY;INTERVAL=3;UNTIL=19970902T170000Z" `shouldBe`
         Just "every 3rd hour until September 02, 1997 at 17:00:00"
+
+    it "every month on Tuesday until November 30, 2021" $ do
+      description <$> fromText "RRULE:BYDAY=TU;INTERVAL=1;FREQ=MONTHLY;UNTIL=20211130" `shouldBe`
+        Just "every month on Tuesday until November 30, 2021"
+
+    it "every other week on Friday until November 19, 1997" $ do
+      description <$> fromText "RRULE:BYDAY=FR;INTERVAL=2;FREQ=WEEKLY;UNTIL=19971119" `shouldBe`
+        Just "every other week on Friday until November 19, 1997"
 
     it "every 15 minutes for 6 occurrences" $ do
       description <$> fromText "FREQ=MINUTELY;INTERVAL=15;COUNT=6" `shouldBe`


### PR DESCRIPTION
On the one hand, thanks for this library, it saved me a lot of work on my own.

On the other hand, the motivation for this PR is that it is also useful to have rules where "UNTIL" is just a plain date and not a time. For instance:

```
"RRULE:BYDAY=TU;INTERVAL=1;FREQ=MONTHLY;UNTIL=20211130
```

This type of rule is valid according to RFC5545, and actually I need this to work in order to insert some recurrent events in Google Calendar.
